### PR TITLE
Put closestDiscoveriesAccordion class in CSS so that its CSS doesn't apply on other stuff outside in the application

### DIFF
--- a/src/components/MapContainer.vue
+++ b/src/components/MapContainer.vue
@@ -36,7 +36,7 @@
   </ion-alert>
 
   <!-- Closest discoveries accordion -->
-  <ion-accordion-group v-if="!isPermissionDenied">
+  <ion-accordion-group class="closestDiscoveriesAccordion" v-if="!isPermissionDenied">
     <ion-accordion>
       <!-- TODO Move recenter button with accordion and update when position changed -->
       <!-- TODO Put between 5 and 12 discoveries depending on discoveries in viewport and add number of discoveries in header?? (to confirm with team to understand what to do) -->

--- a/src/theme/Map.css
+++ b/src/theme/Map.css
@@ -1,28 +1,28 @@
 @import url("@/theme/GlobalStyle.css");
 
 /* Closest discoveries accordion */
-ion-accordion-group {
+ion-accordion-group.closestDiscoveriesAccordion {
     position: absolute;
     bottom: 10.5vh;
     width: 100vw
 }
 
-ion-accordion {
+ion-accordion-group.closestDiscoveriesAccordion ion-accordion {
     border-radius: 16px 16px 0 0;
 }
 
-ion-item[slot="header"] ion-label {
+ion-accordion-group.closestDiscoveriesAccordion ion-accordion ion-item[slot="header"] ion-label {
     font-size: 4vw;
 }
 
-ion-list {
+ion-accordion-group.closestDiscoveriesAccordion ion-accordion div[slot="content"] ion-list {
     display: flex;
     overflow-x: scroll;
     padding: 0 2vw;
     margin:0;
 }
 
-ion-item ion-grid {
+ion-accordion-group.closestDiscoveriesAccordion ion-accordion div[slot="content"] ion-list ion-item ion-grid {
     height: 18vh;
     width: 37vw;
     border-width: 1px;
@@ -68,13 +68,13 @@ ion-row ion-label#closestDiscoveryDistance {
     font-size: 3.2vw;
 }
 
-ion-list ion-item {
+ion-accordion-group.closestDiscoveriesAccordion ion-accordion div[slot="content"] ion-list ion-item {
     flex: 0 0 auto;
     --inner-padding-end: 0vw;
     --padding-start: 2vw;
 }
 
-#seeMoreInList {
+ion-accordion-group.closestDiscoveriesAccordion ion-accordion div[slot="content"] ion-list div#seeMoreInList {
     margin: 0 2vw;
     padding: 10vw;
     height: 18vh;
@@ -108,6 +108,12 @@ ion-list ion-item {
     height: 18vw;
     font-size: 0; /* To hide text */
 }
+.map-button ion-icon {
+    font-size: 3.5vw;
+}
+#recenter-button {
+    bottom: 22vh;
+}
 
 /* isUserLocationInViewport = true */
 #recenter-button.userLocationInViewport {
@@ -128,14 +134,6 @@ ion-list ion-item {
 #recenter-button.userLocationOutsideViewport ion-icon {
     font-size: 5vw;
     margin-right: 3vw;
-}
-
-.map-button ion-icon {
-    font-size: 3.5vw;
-}
-
-#recenter-button {
-    bottom: 22vh;
 }
 
 div#popup.activated {


### PR DESCRIPTION
# Pull Request

## Summary
Put closestDiscoveriesAccordion class in CSS so that its CSS doesn't apply on other stuff outside in the application because it does that with ionic cap build ios/android.

## Changes Made
CSS for MapContainer.vue (which is Map.css) affects elements of the same name outside of Map in the application, so I added identifiers in MapContainer.vue and put them correspondently in Map.css following Kim's recommandation.

## Screenshots (if applicable)
<img width="364" alt="image" src="https://github.com/user-attachments/assets/8c878291-6c4d-4352-8a4c-c28a3034c0cc">

## Related Issues
<!--Reference any related issues that are addressed or resolved by this pull request.-->

## Checklist
Please ensure all the following steps are completed before submitting the pull request:

- [ ] Code passes all existing tests
- [ ] New features or changes are accompanied by appropriate tests
- [ ] Code follows the established coding style and conventions
- [ ] Documentation has been updated to reflect the changes (if applicable)
- [ ] All new and existing tests pass locally

## Additional Notes
<!--Include any additional information or context that may be helpful for reviewers or maintainers.-->