### PR TITLE
Put grayscale CSS filter on basemap layer and put lightgrey background for when map isn't fully loaded

### DIFF
--- a/src/components/MapContainer.vue
+++ b/src/components/MapContainer.vue
@@ -203,6 +203,7 @@ export default {
     const layer = new layerGroup({
       layers: [
         new TileLayer({
+          className: "basemapLayer",
           source: new OSM(),
         }),
       ],

--- a/src/theme/Map.css
+++ b/src/theme/Map.css
@@ -98,6 +98,11 @@ ion-accordion-group.closestDiscoveriesAccordion ion-accordion div[slot="content"
     width: 100%;
 }
 
+.basemapLayer {
+    background-color: #ebebeb; /* background when map hasn't fully loaded when de-zooming quickly */
+    filter: grayscale(0.3); /* make map grayer */
+}
+
 .map-button {
     position: absolute;
     right: 6vw;


### PR DESCRIPTION
# Pull Request

## Summary
Put grayscale CSS filter on basemap layer and put lightgrey background for when map isn't fully loaded.

## Changes Made
Put classname to basemap layer and put filter: grayscale(0.3) to it.

## Screenshots (if applicable)
Before
![image](https://github.com/user-attachments/assets/fcc788c3-5a29-4f43-908c-a99408a11a6d)
Now
![image](https://github.com/user-attachments/assets/258d0c2c-0805-43a1-a2a5-568c29bbfbfb)

## Related Issues
<!--Reference any related issues that are addressed or resolved by this pull request.-->

## Checklist
Please ensure all the following steps are completed before submitting the pull request:

- [ ] Code passes all existing tests
- [ ] New features or changes are accompanied by appropriate tests
- [ ] Code follows the established coding style and conventions
- [ ] Documentation has been updated to reflect the changes (if applicable)
- [ ] All new and existing tests pass locally

## Additional Notes
Didn't put it greyer because I was afraid it would be to grey.