### PR TITLE
Fixed nav bar and recenter button outside of viewport a bit differently for ios and android

### DIFF
--- a/src/components/MapContainer.vue
+++ b/src/components/MapContainer.vue
@@ -23,7 +23,7 @@
     }"
     :fill="isUserLocationInViewport ? 'outline' : 'solid'"
   >
-    <ion-icon :icon="locationIcon"></ion-icon>Recentrer la carte
+    <ion-icon :icon="locationIcon"></ion-icon>RECENTRER LA CARTE
   </ion-button>
 
   <ion-alert

--- a/src/theme/Map.css
+++ b/src/theme/Map.css
@@ -6,6 +6,9 @@ ion-accordion-group.closestDiscoveriesAccordion {
     bottom: 10.5vh;
     width: 100vw
 }
+.ios ion-accordion-group.closestDiscoveriesAccordion {
+    bottom: 14.5vh;
+}
 
 ion-accordion-group.closestDiscoveriesAccordion ion-accordion {
     border-radius: 16px 16px 0 0;
@@ -117,6 +120,9 @@ ion-accordion-group.closestDiscoveriesAccordion ion-accordion div[slot="content"
     font-size: 3.5vw;
 }
 #recenter-button {
+    bottom: 20vh;
+}
+.ios #recenter-button {
     bottom: 22vh;
 }
 
@@ -135,6 +141,9 @@ ion-accordion-group.closestDiscoveriesAccordion ion-accordion div[slot="content"
     font-size: 4vw;
     letter-spacing: 0.02vw;
     font-weight: 500;
+}
+.ios #recenter-button.userLocationOutsideViewport {
+    font-weight: 600;
 }
 #recenter-button.userLocationOutsideViewport ion-icon {
     font-size: 5vw;

--- a/src/views/TabsPage.vue
+++ b/src/views/TabsPage.vue
@@ -106,10 +106,6 @@ export default {
 <style scoped>
 @import url("@/theme/TopToolbar.css");
 
-/*TODO Use grid-template-columns property?
-   justify-content: space-evenly/space-around/space-between*/
-
-/*TODO Use align-items: start and margin-bottom */
 ion-tab-bar {
   padding: 0 4% 0 5%;
   border-top: 0.1vh solid #d9d9d9;
@@ -117,6 +113,9 @@ ion-tab-bar {
   height: 10vh;
   margin: -1px 0 0 0;
   --background: #ffffff;
+}
+.ios ion-tab-bar {
+  padding: 0 4% 4vh 5%;
 }
 
 ion-tab-button {
@@ -128,16 +127,22 @@ ion-tab-button {
   border-radius: 90px;
   padding: 0 1.5vw;
 }
+.ios ion-tab-button {
+  padding: 0 3.8vw;
+}
 
-ion-icon {
+ion-tab-button ion-icon {
   font-size: 6vw;
 }
 
-ion-label {
+ion-tab-button ion-label {
   color: black;
   font-size: 3.7vw;
   padding-left: 2.5vw;
   font-weight: 410;
+}
+.ios ion-tab-button ion-label {
+  font-weight: 500;
 }
 
 ion-tab-button.active-tab {


### PR DESCRIPTION
# Pull Request

## Summary
Adjusted a bit nav bar, text inside nav buttons and recenter button outside of viewport(wasn't in all caps in ios like in android) for ios and android differently in CSS.

## Changes Made
Added .ios with a bit different CSS for the same elements and put text in recenter button outside of viewport in all caps.

## Screenshots (if applicable)
For android, 
![image](https://github.com/user-attachments/assets/9ca44876-93a9-480e-9d02-799b00fe7483)
For ios, 
![image](https://github.com/user-attachments/assets/8fb80148-6042-49f3-8a8b-5c97fd538ee3)

## Related Issues
<!--Reference any related issues that are addressed or resolved by this pull request.-->

## Checklist
Please ensure all the following steps are completed before submitting the pull request:

- [ ] Code passes all existing tests
- [ ] New features or changes are accompanied by appropriate tests
- [ ] Code follows the established coding style and conventions
- [ ] Documentation has been updated to reflect the changes (if applicable)
- [ ] All new and existing tests pass locally

## Additional Notes
Looks like CSS isn't the same for ios and android... we'll have to find a fix, saw in stackoverflow that maybe you have to use classes instead of using ion elements in CSS.