### PR TITLE
Feature/132 for discovery details modale center selected pin and open its description modale

### DIFF
--- a/src/components/MapContainer.vue
+++ b/src/components/MapContainer.vue
@@ -115,6 +115,7 @@
 
   <!-- Selected pin discovery details modal -->
   <ion-modal
+    id="discoveryDetailsModal"
     :is-open="discoveryDetailsModalOpen"
     @didDismiss="this.unfocusDiscovery"
     :breakpoints="[0.2, 0.75, 1]"
@@ -330,7 +331,7 @@ export default {
       this.mainMap = new Map({
         // Hiding attribution (yes it's immoral)
         // ********* To put back Zoom buttons, replace 'zoom: false' by 'zoom: true' ********
-        controls: defaultControls({ attribution: false, zoom: true }),
+        controls: defaultControls({ attribution: false, zoom: false }),
 
         target: "map", // html element id where map will be rendered
         view: new View({
@@ -388,8 +389,8 @@ export default {
       }
     },
 
-    // Shows pins on the map and the pin in params
-    // Called in created() and when the URL params changes
+    // Shows pins on the map
+    // Called in created()
     showPins(discoveries = []) {
       const pinsLayer = new VectorLayer({
         source: new VectorSource(),
@@ -570,7 +571,6 @@ export default {
     focusDiscovery(discovery, map = this.mainMap) {
       if (!discovery) return;
 
-      const transitionDuration = 200; // Unit is milliseconds
       const currentZoom = map.getView().getZoom();
 
       // Highlight clicked pin
@@ -588,7 +588,7 @@ export default {
         map.getView().animate({
           // Center viewport a bit below the selected pin so that the pin is towards the top of viewport
           center: [discovery.location.lng, discovery.location.lat - 0.30 * extentHeight],
-          duration: transitionDuration,
+          duration: 100,
           zoom: Math.max(currentZoom, 14.25),
           easing: easeOut,
         });
@@ -614,7 +614,7 @@ export default {
       }
     },
 
-    // Close modal, if there was a selected pin before, make former selected pin back to normal scale and put formerSelectedPinFeature to null because there are no more selected pin
+    // Close modal, make former selected pin back to normal scale if there was a selected pin before, and put formerSelectedPinFeature to null because there are no more selected pin
     async unfocusDiscovery() {
       this.discoveryDetailsModalOpen = false;
       if (this.formerSelectedPinFeature) {

--- a/src/components/MapContainer.vue
+++ b/src/components/MapContainer.vue
@@ -234,7 +234,7 @@ export default {
         parseInt(this.$route.query.id),
         this.$route.query.type,
       );
-      setTimeout(() => this.focusDiscovery(discovery), 250);
+      setTimeout(() => this.focusDiscovery(discovery), 100);
     }
 
     return {
@@ -288,12 +288,12 @@ export default {
             parseInt(this.$route.query.id),
             this.$route.query.type,
           );
-          this.focusDiscovery(discovery);
+          setTimeout(() => this.focusDiscovery(discovery), 100);
+        } else {
+          this.unfocusDiscovery();
         }
-        this.showPins(); // To change the big pin when focusing on a pin from the map
       },
     );
-    this.renderMap();
   },
 
   async mounted() {
@@ -388,19 +388,6 @@ export default {
       }
     },
 
-    renderMap() {
-      const route = useRoute();
-      const dType = route.params.dType;
-      const id = route.params.id;
-      if (dType && id) {
-        const discovery = Utils.getDiscovery(
-          parseInt(id.toString()),
-          dType.toString(),
-        );
-        this.focusDiscovery(discovery);
-      }
-    },
-
     // Shows pins on the map and the pin in params
     // Called in created() and when the URL params changes
     showPins(discoveries = []) {
@@ -417,20 +404,6 @@ export default {
       } else {
         // Show all discoveries
         insertAllPins(pinsLayer, UserData.getSortedDiscoveriesAZ());
-      }
-
-      // if there's selected pin in url parameters, highlights it
-      if (this.$route.query.type && this.$route.query.id) {
-        const discovery = Utils.getDiscovery(
-          parseInt(this.$route.query.id),
-          this.$route.query.type,
-        );
-        this.highlightSelectedDiscoveryPin(discovery);
-        // if not, if there's a formerly selected pin, returns it back to its original style
-      } else {
-        if (this.formerSelectedPinFeature) {
-          this.formerSelectedPinFeature.setStyle(pinsLayer.getStyle());
-        }
       }
 
       this.mainMap.addLayer(pinsLayer);

--- a/src/theme/Map.css
+++ b/src/theme/Map.css
@@ -1,5 +1,12 @@
 @import url("@/theme/GlobalStyle.css");
 
+/* Selected pin discovery details modal */
+#discoveryDetailsModal {
+    --border-radius: 16px 16px 0px 0px;
+    /*height: 90vh; --makes nav bar visible! */
+}
+/* Selected pin discovery details modal */
+
 /* Closest discoveries accordion */
 ion-accordion-group.closestDiscoveriesAccordion {
     position: absolute;
@@ -150,80 +157,6 @@ ion-accordion-group.closestDiscoveriesAccordion ion-accordion div[slot="content"
     margin-right: 3vw;
 }
 
-div#popup.activated {
-    top: 40%;
-    width: 65vw;
-    height: 12vw;
-    border: 1px solid var(--button-outline-grey);
-}
-
-#popup {
-    perspective-origin: bottom;
-    background: rgba(255, 255, 255, 0.35);
-    backdrop-filter: blur(3px);
-    position: absolute;
-    left: 50%;
-    top: 40%;
-    transform: translate(-50%, -50%);
-    z-index: 1;
-    width: 0;
-    height: 0;
-    border-radius: 10vw;
-    overflow: inherit;
-    transition: all 0.1s cubic-bezier(0, .8, .2, 1);
-}
-
-#popup-details {
-    position: relative;
-    left: 5vw;
-    width: 48vw;
-    height: 12vw;
-    text-overflow: ellipsis;
-    padding-top: 1vw;
-}
-
-#popupTitle {
-    font-size: 16px;
-    font-style: italic;
-    font-weight: bold;
-}
-
-#popupSubtext {
-    position: relative;
-    top: -0.5vw;
-    font-size: 11px;
-    font-weight: 400;
-}
-
-#popupTitle, #popupSubtext {
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    font-family: "OpenSans", sans-serif;
-    color: black;
-    margin: 0;
-}
-
-#popup ion-button {
-    position: absolute;
-    top: 0;
-    right: 2px;
-
-    /* For some reason, increasing this number makes the arrow icon smaller. */
-    font-size: 0;
-
-    width: 10vw;
-    height: 10vw;
-    color: black;
-    --background: none;
-    --ripple-color: var(--mona-yellow);
-    --border-radius: 50%;
-    --border-width: 0;
-}
-
-#seeMore ion-icon {
-    font-size: 32px;
-}
 
 .map-alert {
     --min-width: 90% !important;

--- a/src/views/TabsPage.vue
+++ b/src/views/TabsPage.vue
@@ -61,6 +61,7 @@ import {
   IonIcon,
   IonPage,
   IonRouterOutlet,
+  IonLabel,
 } from "@ionic/vue";
 import inactiveMap from "/assets/drawable/icons/inactive_map_tab_icon.svg";
 import inactiveList from "/assets/drawable/icons/inactive_list_tab_icon.svg";
@@ -79,6 +80,7 @@ export default {
     IonIcon,
     IonPage,
     IonRouterOutlet,
+    IonLabel,
   },
   data() {
     return {


### PR DESCRIPTION
# Pull Request

## Summary
As title says, changed made it apply to clicking on a pin, clicking on discovery from list and closest discoveries.

## Changes Made
Centered pin higher in viewport and opened its description modale when selected.
When clicking on map (outside modale or when closing modale), pin unhighlights and modale closes.

## Screenshots (if applicable)
Now:
<img width="416" alt="image" src="https://github.com/user-attachments/assets/6e2e333c-a8d9-41a1-9249-fabb4bb71a23">

## Related Issues
<!--Reference any related issues that are addressed or resolved by this pull request.-->

## Checklist
Please ensure all the following steps are completed before submitting the pull request:

- [ ] Code passes all existing tests
- [ ] New features or changes are accompanied by appropriate tests
- [ ] Code follows the established coding style and conventions
- [ ] Documentation has been updated to reflect the changes (if applicable)
- [ ] All new and existing tests pass locally

## Additional Notes
<strike>Have to remove zoom controls again.</strike> done!