### PR TITLE
Bug/137 make closest discoveries update and open it when opening app

### DIFF
--- a/src/components/MapContainer.vue
+++ b/src/components/MapContainer.vue
@@ -3,19 +3,6 @@
     <!-- Map container -->
   </div>
 
-  <ion-button
-    @click="recenterView"
-    id="recenter-button"
-    :class="{
-      'map-button': true,
-      userLocationInViewport: isUserLocationInViewport,
-      userLocationOutsideViewport: isUserLocationOutsideViewport,
-    }"
-    :fill="isUserLocationInViewport || isUserLocationOutsideViewport ? 'outline' : 'solid'"
-  >
-    <ion-icon :icon="isUserLocationOutsideViewport ? customLocationIconPurple : customLocationIconBlack"></ion-icon>RECENTRER LA CARTE
-  </ion-button>
-
   <ion-alert
     class="map-alert"
     :is-open="isAlertOpen"
@@ -28,20 +15,31 @@
   <!-- Closest discoveries accordion -->
   <ion-accordion-group
     class="closestDiscoveriesAccordion"
+    value="ionaccordion"
     v-if="!isPermissionDenied"
   >
-    <ion-accordion>
+    <!-- Put the recenter button here so that it moves with the accordion-->
+    <div class="accordionButtonDiv">
+      <ion-button
+      @click="recenterView"
+      id="recenter-button"
+      :class="{
+      'map-button': true,
+      userLocationInViewport: isUserLocationInViewport,
+      userLocationOutsideViewport: isUserLocationOutsideViewport,
+      }"
+      :fill="isUserLocationInViewport || isUserLocationOutsideViewport ? 'outline' : 'solid'"
+      >
+        <ion-icon :icon="isUserLocationOutsideViewport ? customLocationIconPurple : customLocationIconBlack"></ion-icon>RECENTRER LA CARTE
+      </ion-button>
+    </div>
+
+    <ion-accordion value="ionaccordion">
       <!-- TODO Move recenter button with accordion and update when position changed -->
       <!-- TODO Put between 5 and 12 discoveries depending on discoveries in viewport and add number of discoveries in header?? (to confirm with team to understand what to do) -->
       <!-- TODO Check if discoveries match with user location when it changes -->
       <ion-item
         slot="header"
-        @click="
-          this.closestDiscoveriesDistance =
-            UserData.getSortedDiscoveriesDistance().slice(0, 12);
-          this.lat2 = UserData.getLocation()[1];
-          this.lng2 = UserData.getLocation()[0];
-        "
       >
         <ion-label>Découvertes à proximité: </ion-label>
       </ion-item>
@@ -297,6 +295,13 @@ export default {
         }
       },
     );
+
+    // Set closest discoveries to user location when opening map
+    // Timeout because or else, it doesn't show closest discoveries
+    setTimeout(() => {
+      this.updateClosestDiscoveries();
+    }, 1000);
+
   },
 
   async mounted() {
@@ -318,6 +323,14 @@ export default {
   },
 
   methods: {
+
+    updateClosestDiscoveries() {
+      this.closestDiscoveriesDistance =
+          UserData.getSortedDiscoveriesDistance(0, 12);
+      // For distance between discoveries and user location
+      this.lat2 = UserData.getLocation()[1];
+      this.lng2 = UserData.getLocation()[0];
+    },
 
     async askForPermissions() {
       try {
@@ -590,7 +603,7 @@ export default {
         map.getView().animate({
           // Center viewport a bit below the selected pin so that the pin is towards the top of viewport
           center: [discovery.location.lng, discovery.location.lat - 0.30 * extentHeight],
-          duration: 100,
+          duration: 200,
           zoom: Math.max(currentZoom, 14.25),
           easing: easeOut,
         });

--- a/src/components/MapContainer.vue
+++ b/src/components/MapContainer.vue
@@ -13,15 +13,18 @@
   </ion-alert>
 
   <!-- Closest discoveries accordion -->
+
+  <!-- ionChange and :value here are a fix to keep the accordion from re-opening by itself caused by recenter button updating (maybe ionic re-renders accordion when recenter button in it updates) -->
   <ion-accordion-group
     class="closestDiscoveriesAccordion"
-    value="ionaccordion"
     v-if="!isPermissionDenied"
+    :value="ionAccordionOpen ? 'ionaccordion' : ''"
+    @ionChange="ionAccordionOpen = !ionAccordionOpen"
   >
     <!-- Put the recenter button here so that it moves with the accordion-->
     <div class="accordionButtonDiv">
       <ion-button
-      @click="recenterView"
+      @click="this.recenterView(); this.updateClosestDiscoveries();"
       id="recenter-button"
       :class="{
       'map-button': true,
@@ -238,6 +241,7 @@ export default {
     }
 
     return {
+      ionAccordionOpen: true,
       currentSelectedDiscovery: null,
       discoveryDetailsModalOpen: false,
       isPermissionDenied: true,

--- a/src/theme/Map.css
+++ b/src/theme/Map.css
@@ -8,6 +8,12 @@
 /* Selected pin discovery details modal */
 
 /* Closest discoveries accordion */
+
+/* To make ion button follow accordion opening and closing */
+.accordionButtonDiv {
+    position: relative;
+}
+
 ion-accordion-group.closestDiscoveriesAccordion {
     position: absolute;
     bottom: 10.5vh;
@@ -127,10 +133,7 @@ ion-accordion-group.closestDiscoveriesAccordion ion-accordion div[slot="content"
     font-size: 3.5vw;
 }
 #recenter-button {
-    bottom: 20vh;
-}
-.ios #recenter-button {
-    bottom: 22vh;
+    bottom: 4vh;
 }
 
 /* isUserLocationInViewport = true */

--- a/src/views/ListPage.vue
+++ b/src/views/ListPage.vue
@@ -184,6 +184,9 @@ import {
   IonModal,
   IonRadio,
   IonRadioGroup,
+  IonText,
+  IonCol,
+  IonRow,
 } from "@ionic/vue";
 import { filterOutline, close, optionsOutline, reload } from "ionicons/icons";
 import { UserData } from "@/internal/databases/UserData";
@@ -214,6 +217,9 @@ export default {
     IonModal,
     IonRadio,
     IonRadioGroup,
+    IonText,
+    IonCol,
+    IonRow
   },
   setup() {
     return {


### PR DESCRIPTION
Made closest discoveries opened when opening app, made it update at the opening of the app and when clicking on recenter button, and made recenter button follow accordion movement. Also fixed accordion that re-opens by itself when moving on the map (maybe caused by ionic re-rendering when recenter button properties update).

## Changes Made
<!--Detail the changes made in this pull request, including any new features, bug fixes, or enhancements.-->

## Screenshots (if applicable)
<!--Include any relevant screenshots or images to visually demonstrate the changes, if applicable.-->

## Related Issues
<!--Reference any related issues that are addressed or resolved by this pull request.-->

## Checklist
Please ensure all the following steps are completed before submitting the pull request:

- [ ] Code passes all existing tests
- [ ] New features or changes are accompanied by appropriate tests
- [ ] Code follows the established coding style and conventions
- [ ] Documentation has been updated to reflect the changes (if applicable)
- [ ] All new and existing tests pass locally

## Additional Notes
<!--Include any additional information or context that may be helpful for reviewers or maintainers.-->