### PR TITLE
Made more of list discovery titles' content visible

### DIFF
--- a/src/views/ListPage.vue
+++ b/src/views/ListPage.vue
@@ -31,7 +31,7 @@
           >
             <!-- Discovery icon -->
             <ion-avatar slot="start">
-              <img :src="getDiscoveryMedalIcon(discovery)" alt="" />
+              <img :src="getDiscoveryMedalIcon(discovery)" alt="discoveryMedalIcon" />
             </ion-avatar>
             <!-- Discovery to user distance  -->
             <ion-label id="distance" position="fixed" class="ion-text-wrap"
@@ -545,19 +545,20 @@ ion-list {
 }
 
 #list {
-  border: 5px solid #f3f2f7;
-  border-radius: 15px;
+  border-bottom: 5px solid #f3f2f7;
+  border-top: 5px solid #f3f2f7;
+  border-radius: 3vw;
   --min-height: 15vw;
 }
 
-ion-label {
-  padding-left: 15px;
+.titreTrier ion-label, .trierDistance, .trierAZ {
+  padding-left: 4%;
 }
 
 ion-avatar img {
-  margin-top: 5px;
-  max-width: 8vw;
-  max-height: 8vw;
+  margin-top: 10%;
+  max-width: 7.6vw;
+  max-height: 7.6vw;
 }
 
 ion-avatar {
@@ -601,6 +602,7 @@ p.bottom-text {
 }
 
 #title {
+  padding-left: 0.2vw;
   font-weight: bold;
   /* To do so that the title stays on one line and finishes with "..." if it's too long */
   text-overflow: ellipsis;
@@ -608,11 +610,22 @@ p.bottom-text {
   overflow: hidden;
 }
 
+.ios #title {
+  padding-left: 0;
+  font-size: 4vw;
+}
+
 #distance {
+  padding-left: 2vw;
   font-size: small;
-  max-width: 30%;
+  max-width: 20%;
   /* To correct #title sticking to the right bug caused by #distance taking too much space
     (max-width: 200px in Inspect element)*/
+  min-width: 0;
+  /* To override ionic probably shadow DOM setting min-width to 100px*/
+}
+.ios #distance {
+  max-width: 18%;
 }
 
 ion-col img {


### PR DESCRIPTION
# Pull Request

## Summary
Modified list CSS to make more place for discovery title's content. 

## Screenshots (if applicable)
Before: 

![image](https://github.com/user-attachments/assets/afe0967c-f2f4-487a-8430-9ef2d5be4e77)

Now:

<img width="769" alt="image" src="https://github.com/user-attachments/assets/ca91e17f-6d53-43c0-8ca9-cbd26cab0ff3">

## Related Issues
<!--Reference any related issues that are addressed or resolved by this pull request.-->

## Checklist
Please ensure all the following steps are completed before submitting the pull request:

- [ ] Code passes all existing tests
- [ ] New features or changes are accompanied by appropriate tests
- [ ] Code follows the established coding style and conventions
- [ ] Documentation has been updated to reflect the changes (if applicable)
- [ ] All new and existing tests pass locally

## Additional Notes
<!--Include any additional information or context that may be helpful for reviewers or maintainers.-->