### PR TITLE
Corrected description modale opening after taking a picture bug

### DIFF
--- a/src/components/MapContainer.vue
+++ b/src/components/MapContainer.vue
@@ -288,7 +288,7 @@ export default {
     this.$watch(
       () => this.$route.params,
       () => {
-        if (this.$route.query.type && this.$route.query.id) {
+        if (this.$route.query.type && this.$route.query.id && this.$route.path === '/tabs/map') {
           const discovery = Utils.getDiscovery(
             parseInt(this.$route.query.id),
             this.$route.query.type,


### PR DESCRIPTION
# Pull Request

## Summary
Corrected description modale that used to open after adding/taking a picture over comment page bug.

## Changes Made
The problem was this :
![image](https://github.com/user-attachments/assets/0719a0d8-8a2d-4533-94af-b12a66448ea2)
that is still active when on other pages and opens modale (by executing focusDiscovery which opens the modale).

It has been changed to this, so that modale opens only on map page.
The problem is this :
<img width="946" alt="image" src="https://github.com/user-attachments/assets/b96c0cfc-020f-4a3d-a794-1736c2370fa9">
that is still active when on other pages and opens modale (by executing focusDiscovery which opens the modale).

## Screenshots (if applicable)
<!--Include any relevant screenshots or images to visually demonstrate the changes, if applicable.-->

## Related Issues
<!--Reference any related issues that are addressed or resolved by this pull request.-->

## Checklist
Please ensure all the following steps are completed before submitting the pull request:

- [ ] Code passes all existing tests
- [ ] New features or changes are accompanied by appropriate tests
- [ ] Code follows the established coding style and conventions
- [ ] Documentation has been updated to reflect the changes (if applicable)
- [ ] All new and existing tests pass locally

## Additional Notes
<!--Include any additional information or context that may be helpful for reviewers or maintainers.-->