### PR TITLE
Made 'Member since' disappear when creation date isn't available and centered username that's next to it

### DIFF
--- a/src/views/CollectionPage.vue
+++ b/src/views/CollectionPage.vue
@@ -96,7 +96,7 @@ export default {
         "Novembre",
         "Décembre",
       ];
-      //this.memberSince = monthsArray[month - 1] + " " + year;
+      this.memberSince = monthsArray[month - 1] + " " + year;
     }
   },
   methods: {

--- a/src/views/CollectionPage.vue
+++ b/src/views/CollectionPage.vue
@@ -3,8 +3,8 @@
     <div id="userInfo">
       <ion-icon id="defaultUserAvatar" :icon="defaultUserAvatar"></ion-icon>
       <div id="userInfoText">
-        <h1>{{ username }}</h1>
-        <h6>Membre depuis {{ memberSince }}</h6>
+        <h1 :style="{paddingTop: memberSince? '0' : '1.1vh'}">{{ username }}</h1>
+        <h6 v-if="memberSince">Membre depuis {{ memberSince }}</h6>
       </div>
     </div>
       <div class="ion-segment-container collectionPageSegment">
@@ -96,7 +96,7 @@ export default {
         "Novembre",
         "Décembre",
       ];
-      this.memberSince = monthsArray[month - 1] + " " + year;
+      //this.memberSince = monthsArray[month - 1] + " " + year;
     }
   },
   methods: {


### PR DESCRIPTION
# Pull Request
## Screenshots (if applicable)
When creation date isn't available:
<img width="337" alt="image" src="https://github.com/user-attachments/assets/1fada498-164e-42de-9583-c93a3e9baa56">
VS 
when it is:
<img width="337" alt="image" src="https://github.com/user-attachments/assets/b2b48381-8ff7-4284-a04d-df4847c4845d">


## Related Issues
<!--Reference any related issues that are addressed or resolved by this pull request.-->

## Checklist
Please ensure all the following steps are completed before submitting the pull request:

- [ ] Code passes all existing tests
- [ ] New features or changes are accompanied by appropriate tests
- [ ] Code follows the established coding style and conventions
- [ ] Documentation has been updated to reflect the changes (if applicable)
- [ ] All new and existing tests pass locally

## Additional Notes
<!--Include any additional information or context that may be helpful for reviewers or maintainers.-->