### PR TITLE
Removed 'public/' in front of icon image url

### DIFF
--- a/src/components/DiscoveryDetailsFullModale.vue
+++ b/src/components/DiscoveryDetailsFullModale.vue
@@ -202,7 +202,7 @@
                 <li :key="st" v-for="st in 5">
                   <ion-icon
                     size="small"
-                    :icon="`public/assets/drawable/icons/greyStar.svg`"
+                    :icon="`/assets/drawable/icons/greyStar.svg`"
                   ></ion-icon>
                 </li>
               </ul>
@@ -217,7 +217,7 @@
                 <li :key="st" v-for="st in this.getRating()">
                   <ion-icon
                     size="small"
-                    :icon="`public/assets/drawable/icons/yellowStar.svg`"
+                    :icon="`/assets/drawable/icons/yellowStar.svg`"
                   ></ion-icon>
                 </li>
                 <li>


### PR DESCRIPTION
# Pull Request

## Summary
Removed 'public/' in front of icon image url and, now, stars show in Commentaire tab in full discovery details modale.

## Changes Made
<!--Detail the changes made in this pull request, including any new features, bug fixes, or enhancements.-->

## Screenshots (if applicable)
<!--Include any relevant screenshots or images to visually demonstrate the changes, if applicable.-->

## Related Issues
<!--Reference any related issues that are addressed or resolved by this pull request.-->

## Checklist
Please ensure all the following steps are completed before submitting the pull request:

- [ ] Code passes all existing tests
- [ ] New features or changes are accompanied by appropriate tests
- [ ] Code follows the established coding style and conventions
- [ ] Documentation has been updated to reflect the changes (if applicable)
- [ ] All new and existing tests pass locally

## Additional Notes
<!--Include any additional information or context that may be helpful for reviewers or maintainers.-->