### PR TITLE
Feature/206 Made search bar stick to top of viewport and added padding

### DIFF
--- a/src/views/ListPage.vue
+++ b/src/views/ListPage.vue
@@ -571,6 +571,8 @@ div.main-content {
 
 ion-list {
   background: #f3f2f7;
+  /* To override ionic setting margin-top to 16px, since padding-bottom was added to the search bar */
+  margin-top: 12px!important;
 }
 
 #list {
@@ -598,10 +600,18 @@ ion-col {
 }
 
 #searchbarAndFilterButton {
+  background: #f3f2f7;
   padding-top: 6%;
   display: flex;
   align-items: center;
-  margin-left: 4vw;
+  padding-left: 4vw;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding-bottom: 1%;
+  /* To prevent thin white line from appearing in-between the search bar and the list
+    due to fractional pixel gap. */
+  border-bottom: 1px solid #f3f2f7;
 }
 .ios #searchbarAndFilterButton {
   padding-top: 15%;

--- a/src/views/ListPage.vue
+++ b/src/views/ListPage.vue
@@ -572,7 +572,7 @@ div.main-content {
 ion-list {
   background: #f3f2f7;
   /* To override ionic setting margin-top to 16px, since padding-bottom was added to the search bar */
-  margin-top: 12px!important;
+  margin-top: 3%!important;
 }
 
 #list {


### PR DESCRIPTION
# Pull Request

## Summary
Search bar now sticks on top of ListPage viewport.

## Changes Made
Made search bar and filter sticky and added padding-bottom to create space between the search bar and the list elements.
Reduced list margin-top to account for the new search bar padding-bottom.

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/f4b62906-f5f4-4008-9564-c38bc93de1c0)

## Related Issues
Issue #206

## Checklist
Please ensure all the following steps are completed before submitting the pull request:

- [ ] Code passes all existing tests
- [ ] New features or changes are accompanied by appropriate tests
- [ ] Code follows the established coding style and conventions
- [ ] Documentation has been updated to reflect the changes (if applicable)
- [ ] All new and existing tests pass locally

## Additional Notes
<!--Include any additional information or context that may be helpful for reviewers or maintainers.-->