### PR TITLE
Feature/124 made highlighted pin appear in front of other pins

### DIFF
--- a/src/components/MapContainer.vue
+++ b/src/components/MapContainer.vue
@@ -520,7 +520,8 @@ export default {
       return [style];
     },
 
-    // Makes selected discovery pin bigger, makes it red, and re-establishes former selected pin's size
+    // Makes selected discovery pin bigger, makes it red, makes it appear on top of the other pins, 
+    // and re-establishes former selected pin's size
     highlightSelectedDiscoveryPin(selectedPinDiscovery) {
       // if there was a selected pin before, make former selected pin back to normal scale
       if (this.formerSelectedPinFeature) {

--- a/src/components/MapContainer.vue
+++ b/src/components/MapContainer.vue
@@ -542,6 +542,7 @@ export default {
           src: `./assets/drawable/pins/selected_pin.svg`,
           scale: 0.83, // Augment selected pin size
         }),
+        zIndex: 2, // Ensures selected pin appears on top
       });
       selectedFeature.setStyle(selectedPinStyle);
 


### PR DESCRIPTION
# Pull Request

## Summary
Selected pin now appears on top of the other pins.

## Changes Made
Added `zIndex` property to `selectedPinStyle` in `highlightSelectedDiscoveryPin()` function, in `MapContainer.vue`.

## Screenshots (if applicable)
Before:
![image](https://github.com/user-attachments/assets/c936b0ce-39e7-44ad-810f-0e675532d742)

After:
![image](https://github.com/user-attachments/assets/62c9b509-854d-4764-bfe9-e7d21f725c92)

## Related Issues
Issue #124 

## Checklist
Please ensure all the following steps are completed before submitting the pull request:

- [ ] Code passes all existing tests
- [ ] New features or changes are accompanied by appropriate tests
- [ ] Code follows the established coding style and conventions
- [ ] Documentation has been updated to reflect the changes (if applicable)
- [ ] All new and existing tests pass locally

## Additional Notes
<!--Include any additional information or context that may be helpful for reviewers or maintainers.-->