### PR TITLE
Feature/139 Remove existing location layers when location refreshes

### DIFF
--- a/src/components/MapContainer.vue
+++ b/src/components/MapContainer.vue
@@ -277,6 +277,10 @@ export default {
       currentSelectedDiscovery: null,
       discoveryDetailsModalOpen: false,
       isPermissionDenied: true,
+      userLocationLayer: null,
+      locationAccuracyLayer: null,
+      userPointFeature: null,
+      locationUpdateInterval: null,
       mapPinsLayer: null,
       lat2: UserData.getLocation()[1],
       lng2: UserData.getLocation()[0],
@@ -551,8 +555,17 @@ export default {
     },
 
     showLocation() {
-      //User location accuracy radius in meters (transparent blue circle)
-      const locationAccuracyLayer = new VectorLayer({
+      // Remove existing layers if they exist
+      if (this.locationAccuracyLayer) {
+        this.mainMap.removeLayer(this.locationAccuracyLayer);
+      }
+      
+      if (this.userLocationLayer) {
+        this.mainMap.removeLayer(this.userLocationLayer);
+      }
+
+      // User location accuracy radius in meters (transparent blue circle)
+      this.locationAccuracyLayer = new VectorLayer({
         source: new VectorSource(),
         style: [
           new Style({
@@ -562,15 +575,17 @@ export default {
           }),
         ],
       });
-      locationAccuracyLayer.getSource().addFeature(
+      
+      this.locationAccuracyLayer.getSource().addFeature(
         new Feature({
           geometry: circular(UserData.getLocation(), UserData.getAccuracy()),
-        }),
+        })
       );
-      this.mainMap.addLayer(locationAccuracyLayer);
+      
+      this.mainMap.addLayer(this.locationAccuracyLayer);
 
-      //User location icon (blue opaque circle with white outline)
-      const userLocationLayer = new VectorLayer({
+      // User location icon (blue opaque circle with white outline)
+      this.userLocationLayer = new VectorLayer({
         source: new VectorSource(),
         style: [
           // Trying to put a slight shadow behind user location image to see it better on the map
@@ -596,22 +611,34 @@ export default {
           }),
         ],
       });
-      const userPointFeature = new Feature({
+      
+      this.userPointFeature = new Feature({
         geometry: new Point(UserData.getLocation()),
       });
-      userLocationLayer.getSource().addFeature(userPointFeature);
-      this.mainMap.addLayer(userLocationLayer);
+      
+      this.userLocationLayer.getSource().addFeature(this.userPointFeature);
+      this.mainMap.addLayer(this.userLocationLayer);
 
       // Update location and accuracy radius every 5 seconds
-      setInterval(() => {
-        userPointFeature.getGeometry().setCoordinates(UserData.getLocation());
-        locationAccuracyLayer
-          .getSource()
-          .getFeatures()[0]
-          .setGeometry(
-            circular(UserData.getLocation(), UserData.getAccuracy()),
-          );
+      clearInterval(this.locationUpdateInterval); // Clear any existing interval
+      this.locationUpdateInterval = setInterval(() => {
+        if (this.userPointFeature && this.locationAccuracyLayer) {
+          this.userPointFeature.getGeometry().setCoordinates(UserData.getLocation());
+          const accuracyFeature = this.locationAccuracyLayer.getSource().getFeatures()[0];
+          if (accuracyFeature) {
+            accuracyFeature.setGeometry(
+              circular(UserData.getLocation(), UserData.getAccuracy())
+            );
+          }
+        }
       }, 5000);
+    },
+
+    beforeDestroy() {
+      // Clean up interval when component is destroyed
+      if (this.locationUpdateInterval) {
+       clearInterval(this.locationUpdateInterval);
+      }
     },
 
     // Handles click on the map


### PR DESCRIPTION
# Pull Request

## Summary
Removed existing location layers when location refreshes

## Changes Made
`showLocation()` now removes existing layers when location refreshes. 
`clearInterval()` clears any previously existing interval before creating a new interval. Now, only one interval runs at a time.
Internal ID now stored as component property in `this.locationUpdateInterval`
Added safety checks such as `if (this.userPointFeature && this.locationAccuracyLayer)`
`beforeDestroy()` clears interval when component is destroyed, for cleanup/garbage collection.
Some local variables changed to component properties using `this` keyword.

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/62d89e45-6695-47e2-95e5-8f49f3a6c98f)

## Checklist
Please ensure all the following steps are completed before submitting the pull request:

- [ ] Code passes all existing tests
- [ ] New features or changes are accompanied by appropriate tests
- [ ] Code follows the established coding style and conventions
- [ ] Documentation has been updated to reflect the changes (if applicable)
- [ ] All new and existing tests pass locally