### PR TITLE
Feature/223 make badges clickabletappable

### DIFF
--- a/src/components/BadgesContainer.vue
+++ b/src/components/BadgesContainer.vue
@@ -18,7 +18,7 @@
           :alt="elem.message"
           :src="elem.src"
           style="max-width: none"
-          @click="debuggingToDelete"
+          @click="openBadgeDetails(elem)"
         />
         <span style="margin-top: 2%; font-size: small"> {{ elem.title }} </span>
       </swiper-slide>
@@ -35,7 +35,7 @@
         class="ion-margin-bottom ion-margin-top border"
       >
         <ion-col size="auto">
-          <img :alt="elem.message" :src="elem.src" />
+          <img :alt="elem.message" :src="elem.src" @click="openBadgeDetails(elem)" />
         </ion-col>
         <ion-col>
           <div class="container_progression">
@@ -66,7 +66,7 @@
         class="ion-margin-bottom ion-margin-top border"
       >
         <ion-col size="auto">
-          <img :alt="elem.message" :src="elem.src" />
+          <img :alt="elem.message" :src="elem.src" @click="openBadgeDetails(elem)" />
         </ion-col>
         <ion-col>
           <div class="container_progression">
@@ -90,7 +90,7 @@
         class="ion-margin-bottom ion-margin-top border"
       >
         <ion-col size="auto">
-          <img :alt="elem.message" :src="elem.src" />
+          <img :alt="elem.message" :src="elem.src" @click="openBadgeDetails(elem)" />
         </ion-col>
         <ion-col>
           <div class="container_progression">
@@ -110,10 +110,35 @@
       </ion-row>
     </div>
   </div>
+
+  <!-- Badge Details Modal -->
+  <ion-modal :is-open="isBadgeModalOpen" @didDismiss="closeBadgeModal" class="badge-details-modal">
+    <div class="badge-modal-content">
+      <div class="badge-header">
+        <img :src="selectedBadge?.src" alt="Badge" class="badge-image" />
+        <h2>{{ selectedBadge?.title }}</h2>
+      </div>
+      
+      <div class="badge-description">
+        <p>{{ selectedBadge?.description }}</p>
+        
+        <div class="badge-progress" v-if="selectedBadge?.requireCount">
+          <p v-if="selectedBadge.count >= selectedBadge.requireCount" class="completed-badge">
+            Badge complété!
+          </p>
+          <p v-else>
+            Progression: {{ selectedBadge.count || 0 }}/{{ selectedBadge.requireCount }}
+          </p>
+        </div>
+      </div>
+      
+      <ion-button expand="block" @click="closeBadgeModal" class="close-button">Fermer</ion-button>
+    </div>
+  </ion-modal>
 </template>
 
 <script>
-import { IonLabel, IonProgressBar, IonRow, IonCol, IonIcon } from "@ionic/vue";
+import { IonLabel, IonProgressBar, IonRow, IonCol, IonIcon, IonModal, IonButton } from "@ionic/vue";
 import { Swiper, SwiperSlide } from "swiper/vue";
 import "swiper/css";
 import "@ionic/vue/css/ionic-swiper.css";
@@ -129,6 +154,8 @@ export default {
     IonRow,
     IonCol,
     IonIcon,
+    IonModal,
+    IonButton,
     Swiper,
     SwiperSlide,
   },
@@ -148,7 +175,9 @@ export default {
   data() {
     return {
       showCategories: true,
-      showNeighborhoods: true
+      showNeighborhoods: true,
+      isBadgeModalOpen: false,
+      selectedBadge: null
     };
   },
   computed: {
@@ -162,6 +191,13 @@ export default {
     },
     toggleNeighborhoods() {
       this.showNeighborhoods = !this.showNeighborhoods;
+    },
+    openBadgeDetails(badge) {
+      this.selectedBadge = badge;
+      this.isBadgeModalOpen = true;
+    },
+    closeBadgeModal() {
+      this.isBadgeModalOpen = false;
     },
     debuggingToDelete() {
       console.log("userCollectedDiscovery:", badgesCollectionsStore.userCollectedDiscovery);
@@ -241,5 +277,108 @@ a {
 
 .section-header ion-icon {
   font-size: 24px;
+}
+
+/* Badge Modal Styles */
+.badge-details-modal {
+  --height: auto;
+  --width: 80%;
+  --border-radius: 4vw;
+  --box-shadow: 0 2vh 3vh rgba(0, 0, 0, 0.2);
+}
+
+.badge-modal-content {
+  padding: 5vh 5vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: white;
+  border-radius: 4vw;
+}
+
+.badge-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 3vh;
+  text-align: center;
+}
+
+.badge-image {
+  width: 30vw;
+  height: auto;
+  margin-bottom: 2vh;
+}
+
+.badge-header h2 {
+  font-size: 5vw;
+  font-weight: bold;
+  margin: 0;
+}
+
+.badge-description {
+  text-align: center;
+  margin-bottom: 4vh;
+  width: 90%;
+}
+
+.badge-description p {
+  font-size: 3.8vw;
+  line-height: 1.4;
+  color: #444;
+}
+
+.badge-progress {
+  margin-top: 2vh;
+  font-weight: 500;
+}
+
+.completed-badge {
+  color: #facc00;
+  font-weight: bold;
+}
+
+.close-button {
+  --background: var(--mona-yellow);
+  --color: black;
+  --border-radius: 2vw;
+  font-weight: 500;
+  margin-top: 2vh;
+  height: 5vh;
+}
+
+img[alt="Badge"] {
+  cursor: pointer;
+}
+
+/* For badges in the swiper */
+.badgeContainer img {
+  cursor: pointer;
+  transition: transform 0.2s, filter 0.2s;
+}
+
+.badgeContainer img:hover {
+  transform: scale(1.05);
+  filter: brightness(1.1);
+}
+
+/* For badges in the lists */
+ion-col img {
+  cursor: pointer;
+  transition: transform 0.2s, filter 0.2s;
+}
+
+ion-col img:hover {
+  transform: scale(1.05);
+  filter: brightness(1.1);
+}
+
+/* For badge title/name in the swiper */
+.badgeContainer span {
+  transition: color 0.2s;
+}
+
+.badgeContainer:hover span {
+  color: #4D58CB;
 }
 </style>

--- a/src/components/BadgesContainer.vue
+++ b/src/components/BadgesContainer.vue
@@ -13,12 +13,12 @@
         :key="elem"
         class="badgeContainer ion-margin-end border ion-padding"
         style="height: 100%"
+        @click="openBadgeDetails(elem)"
       >
         <img
           :alt="elem.message"
           :src="elem.src"
           style="max-width: none"
-          @click="openBadgeDetails(elem)"
         />
         <span style="margin-top: 2%; font-size: small"> {{ elem.title }} </span>
       </swiper-slide>
@@ -32,14 +32,15 @@
       <ion-row
         v-for="elem in badgesCollectionsStore.categoryCollection"
         :key="elem"
-        class="ion-margin-bottom ion-margin-top border"
+        class="ion-margin-bottom ion-margin-top border badge-row"
+        @click="openBadgeDetails(elem)"
       >
         <ion-col size="auto">
-          <img :alt="elem.message" :src="elem.src" @click="openBadgeDetails(elem)" />
+          <img :alt="elem.message" :src="elem.src" />
         </ion-col>
         <ion-col>
           <div class="container_progression">
-            <ion-label>{{ elem.title.fr }}</ion-label>
+            <ion-label>{{ typeof elem.title === 'object' ? elem.title.fr : elem.title }}</ion-label>
             <div class="progressBar ion-margin-top">
               <span class="ion-margin-end"
                     :style="{color: elem.count >= elem.requireCount ? '#facc00' : 'black'}">{{
@@ -63,10 +64,11 @@
       <ion-row
         v-for="elem in badgesCollectionsStore.boroughCollection"
         :key="elem"
-        class="ion-margin-bottom ion-margin-top border"
+        class="ion-margin-bottom ion-margin-top border badge-row"
+        @click="openBadgeDetails(elem)"
       >
         <ion-col size="auto">
-          <img :alt="elem.message" :src="elem.src" @click="openBadgeDetails(elem)" />
+          <img :alt="elem.message" :src="elem.src" />
         </ion-col>
         <ion-col>
           <div class="container_progression">
@@ -87,10 +89,11 @@
       <ion-row
         v-for="elem in badgesCollectionsStore.ownerCollection"
         :key="elem"
-        class="ion-margin-bottom ion-margin-top border"
+        class="ion-margin-bottom ion-margin-top border badge-row"
+        @click="openBadgeDetails(elem)"
       >
         <ion-col size="auto">
-          <img :alt="elem.message" :src="elem.src" @click="openBadgeDetails(elem)" />
+          <img :alt="elem.message" :src="elem.src" />
         </ion-col>
         <ion-col>
           <div class="container_progression">
@@ -116,11 +119,11 @@
     <div class="badge-modal-content">
       <div class="badge-header">
         <img :src="selectedBadge?.src" alt="Badge" class="badge-image" />
-        <h2>{{ selectedBadge?.title }}</h2>
+        <h2>{{ getBadgeTitle(selectedBadge) }}</h2>
       </div>
       
       <div class="badge-description">
-        <p>{{ selectedBadge?.description }}</p>
+        <p>{{ getBadgeDescription(selectedBadge) }}</p>
         
         <div class="badge-progress" v-if="selectedBadge?.requireCount">
           <p v-if="selectedBadge.count >= selectedBadge.requireCount" class="completed-badge">
@@ -186,6 +189,30 @@ export default {
     },
   },
   methods: {
+    getBadgeTitle(badge) {
+      if (!badge) return '';
+      
+      // Check if title is an object with 'fr' property
+      if (badge.title && typeof badge.title === 'object' && badge.title.fr) {
+        return badge.title.fr;
+      }
+      
+      // Return title as is if it's a string
+      return badge.title;
+    },
+    
+    getBadgeDescription(badge) {
+      if (!badge) return '';
+      
+      // Check if description is an object with 'fr' property
+      if (badge.description && typeof badge.description === 'object' && badge.description.fr) {
+        return badge.description.fr;
+      }
+      
+      // Return description as is if it's a string
+      return badge.description;
+    },
+    
     toggleCategories() {
       this.showCategories = !this.showCategories;
     },
@@ -263,6 +290,7 @@ a {
   justify-content: center;
   align-items: center;
   padding: 1%;
+  cursor: pointer;
 }
 .swiper .swiper-slide {
   height: auto !important;
@@ -279,7 +307,12 @@ a {
   font-size: 24px;
 }
 
-/* Badge Modal Styles */
+/* Make rows clickable */
+.badge-row {
+  cursor: pointer;
+}
+
+/* Badge Modal Styles with relative units */
 .badge-details-modal {
   --height: auto;
   --width: 80%;
@@ -347,28 +380,18 @@ a {
   height: 5vh;
 }
 
-img[alt="Badge"] {
-  cursor: pointer;
-}
-
 /* For badges in the swiper */
 .badgeContainer img {
-  cursor: pointer;
   transition: transform 0.2s, filter 0.2s;
 }
 
-.badgeContainer img:hover {
+.badgeContainer:hover img {
   transform: scale(1.05);
   filter: brightness(1.1);
 }
 
 /* For badges in the lists */
-ion-col img {
-  cursor: pointer;
-  transition: transform 0.2s, filter 0.2s;
-}
-
-ion-col img:hover {
+.badge-row:hover img {
   transform: scale(1.05);
   filter: brightness(1.1);
 }

--- a/src/internal/CollectedBadges.ts
+++ b/src/internal/CollectedBadges.ts
@@ -3,6 +3,7 @@ import { useBadgesDB } from "@/stores/BadgesDB";
 import { Artwork, Heritage, Place } from "@/internal/Types";
 import Utils from "@/internal/Utils";
 import { BadgeDatabase } from "@/internal/databases/BadgeDatabase";
+import { useBadgesCollections } from "@/stores/BadgesCollections";
 
 export class CollectedBadge {
   private static badgesDB = useBadgesDB();
@@ -31,6 +32,7 @@ export class CollectedBadge {
     const tmpBoroughContainer = new Map<string, number>();
     const tmpOwnerContainer = new Map<string, number>();
     const tmpCategoryContainer = new Map<string, number>();
+    const badgesCollectionsStore = useBadgesCollections();
 
     this.badgesDB = useBadgesDB();
     this.userCollection = UserData.getCollectedChronologically();

--- a/src/internal/Types.ts
+++ b/src/internal/Types.ts
@@ -375,4 +375,8 @@ export class Badge extends Discovery {
   public getTitle(): string {
     return this.title.fr;
   }
+
+  public getNotification(lang = "fr"): string {
+    return lang === "fr" ? this.notification.fr : this.notification.en;
+  }
 }

--- a/src/internal/Types.ts
+++ b/src/internal/Types.ts
@@ -379,4 +379,8 @@ export class Badge extends Discovery {
   public getNotification(lang = "fr"): string {
     return lang === "fr" ? this.notification.fr : this.notification.en;
   }
+
+  public getDescription(lang = "fr"): string {
+    return lang === "fr" ? this.description.fr : this.description.en;
+  }
 }

--- a/src/stores/BadgesCollections.ts
+++ b/src/stores/BadgesCollections.ts
@@ -4,6 +4,7 @@ import { useBadgesDB } from "@/stores/BadgesDB";
 import { UserData } from "@/internal/databases/UserData";
 import { BadgeDatabase } from "@/internal/databases/BadgeDatabase";
 import { Artwork, Heritage, Place } from "@/internal/Types";
+import { toastController } from "@ionic/vue";
 
 const countPathLocked = "/assets/drawable/badges/count/locked/";
 const countPathUnlocked = "/assets/drawable/badges/count/unlocked/";
@@ -69,6 +70,23 @@ export const useBadgesCollections = defineStore("badgesCollectionStore", {
   },
 
   actions: {
+    // Show a toast notification when a badge is unlocked
+    async showBadgeNotification(badgeId: number) {
+      const badge = BadgeDatabase.getFromId(badgeId);
+      if (!badge) return;
+      
+      const notificationText = badge.notification?.fr || badge.title?.fr || "Nouveau badge débloqué !";
+      
+      const toast = await toastController.create({
+        message: notificationText,
+        duration: 4000, // Duration in milliseconds
+        position: 'top',
+        color: 'warning',
+        cssClass: 'badge-notification-toast'
+      });
+      
+      await toast.present();
+    },
 
     // Instantiate the badges to show for each type of badges
     instantiateBadgesToShow() {
@@ -210,9 +228,12 @@ export const useBadgesCollections = defineStore("badgesCollectionStore", {
         for (const elem of this.boroughCollection) {
           if (elem.title === borough) {
             elem.count++;
+            // Check if the badge is newly completed
             if (elem.count === elem.requireCount) {
               elem.src = boroughPathUnlocked + elem.id + ".svg";
               console.log("borough unlocked");
+              // Show notification for newly unlocked badge
+              this.showBadgeNotification(elem.id);
             }
             UserData.addCollectedBadge(elem);
           }
@@ -224,9 +245,12 @@ export const useBadgesCollections = defineStore("badgesCollectionStore", {
         for (const elem of this.categoryCollection) {
           if (elem.dType === category) {
             elem.count++;
+            // Check if the badge is newly completed
             if (elem.count === elem.requireCount) {
               elem.src = categoryPathUnlocked + elem.id + ".svg";
               console.log("category unlocked");
+              // Show notification for newly unlocked badge
+              this.showBadgeNotification(elem.id);
             }
             UserData.addCollectedBadge(elem);
           }
@@ -240,9 +264,12 @@ export const useBadgesCollections = defineStore("badgesCollectionStore", {
           if (elem.title === owner) {
             console.log("in if");
             elem.count++;
+            // Check if the badge is newly completed
             if (elem.count === elem.requireCount) {
               elem.src = ownerPathUnlocked + elem.id + ".svg";
               console.log("owner unlocked");
+              // Show notification for newly unlocked badge
+              this.showBadgeNotification(elem.id);
             }
             UserData.addCollectedBadge(elem);
           }
@@ -256,13 +283,12 @@ export const useBadgesCollections = defineStore("badgesCollectionStore", {
           if (elem.requireCount === this.userCollectedDiscovery.length) {
             elem.src = countPathUnlocked + elem.id + ".svg";
             console.log("count unlocked");
+            // Show notification for newly unlocked badge
+            this.showBadgeNotification(elem.id);
             UserData.addCollectedBadge(elem);
           }
         }
       }
     },
-    // newBadgeCompleted() {
-    //   return (this.newBadgeAnimation = true);
-    // },
   },
 });

--- a/src/stores/BadgesCollections.ts
+++ b/src/stores/BadgesCollections.ts
@@ -283,6 +283,11 @@ export const useBadgesCollections = defineStore("badgesCollectionStore", {
           if (elem.requireCount === this.userCollectedDiscovery.length) {
             elem.src = countPathUnlocked + elem.id + ".svg";
             console.log("count unlocked");
+            // Ensure the badge has its description for the modal
+            const badgeFromDB = BadgeDatabase.getFromId(elem.id);
+            if (badgeFromDB && badgeFromDB.description?.fr) {
+              elem.description = badgeFromDB.description.fr;
+            }
             // Show notification for newly unlocked badge
             this.showBadgeNotification(elem.id);
             UserData.addCollectedBadge(elem);

--- a/src/theme/GlobalStyle.css
+++ b/src/theme/GlobalStyle.css
@@ -36,8 +36,17 @@
     --border-style: solid;
     --border-width: 2px;
     --border-color: #dabb00;
+    margin-top: 10px; /* Create space between toasts */
   }
   
   .badge-notification-toast::part(message) {
     padding: 12px 8px;
   }
+  /* TODO: make multiple toasts appear one after the other instead of one after the other */
+  
+  /* Override Ionic's default toast container to allow proper stacking of badge notification toast */
+  ion-toast.badge-notification-toast {
+    position: static !important;
+    transform: none !important;
+  }
+  

--- a/src/theme/GlobalStyle.css
+++ b/src/theme/GlobalStyle.css
@@ -23,3 +23,21 @@
     --ion-color-primary: var(--mona-yellow);
     --ion-color-primary-contrast: #000000;
 }
+
+/* For notification toast upon obtention of new badge, which could appear in any page. */
+.badge-notification-toast {
+    font-weight: 500;
+    --background: var(--mona-yellow);
+    --color: black;
+    --border-radius: 8px;
+    --box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2);
+    text-align: center;
+    --width: 90%;
+    --border-style: solid;
+    --border-width: 2px;
+    --border-color: #dabb00;
+  }
+  
+  .badge-notification-toast::part(message) {
+    padding: 12px 8px;
+  }


### PR DESCRIPTION
# Pull Request

## Summary
Added badge modals. Clicking on a badge opens the modal.

## Changes Made
Uses ion-modal. Modified BadgesContainer.vue to added on-click event listener on badges, added modals, and modal CSS. Added badge description getter to Types.ts. Modified BadgesCollections.ts to get the description.

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/c3253347-242b-4caa-a9f0-a2857f742c97)

![image](https://github.com/user-attachments/assets/dd0f3474-27da-47a2-9477-409cdb2ce393)