### PR TITLE
Add data version checks and schema management before DB populate

### DIFF
--- a/src/internal/databases/UserData.ts
+++ b/src/internal/databases/UserData.ts
@@ -25,14 +25,15 @@ export class UserData {
   private static type = "preferences";
   // Keep these version counters in sync with our storage formats.
   // - Increment CACHE_SCHEMA_VERSION whenever the shape of discoveries_sorted.json (the
-  //   cached, sorted discovery list we store via Filesystem in Directory.Cache)
+  //   client-generated, cached sorted discovery list we store via Filesystem in Directory.Cache)
   //   changes
-  //   (e.g., we add/remove fields, rename properties, or alter the wrapper structure).
+  //   (e.g., we change how a field is serialized, add/remove fields client-side, rename properties, or alter the wrapper structure).
+  //
   // - Increment DATA_SCHEMA_VERSION whenever preferences.json or the downloaded DB JSON
-  //   payloads (artworks/places/heritages/badges) change in a way that requires us to
+  //   payloads (artworks/places/heritages/badges) we mirror from the server change in a way that requires us to
   //   wipe and repopulate local files for older installs. This ensures users automatically
   //   refresh their local data after we ship schema-affecting releases.
-  //   (e.g., new/removed/renamed field to the artworks API, etc.)
+  //   (e.g., new/removed/renamed field to the artworks, heritages, places, badges server database API, etc.)
   private static readonly CACHE_SCHEMA_VERSION = 1;
   private static readonly DATA_SCHEMA_VERSION = 1;
   private static readonly DATABASE_PATHS = [

--- a/src/internal/databases/UserData.ts
+++ b/src/internal/databases/UserData.ts
@@ -23,6 +23,21 @@ export class UserData {
   private static path = "appdata/preferences.json";
   private static cachePath = "discoveries_sorted.json";
   private static type = "preferences";
+  // Keep these version counters in sync with our storage formats.
+  // - Bump CACHE_SCHEMA_VERSION whenever the shape of discoveries_sorted.json changes
+  //   (e.g., we add/remove fields, rename properties, or alter the wrapper structure).
+  // - Bump DATA_SCHEMA_VERSION whenever preferences.json or the downloaded DB JSON
+  //   payloads (artworks/places/heritages/badges) change in a way that requires us to
+  //   wipe and repopulate local files for older installs. This ensures users automatically
+  //   refresh their local data after we ship schema-affecting releases.
+  private static readonly CACHE_SCHEMA_VERSION = 1;
+  private static readonly DATA_SCHEMA_VERSION = 1;
+  private static readonly DATABASE_PATHS = [
+    "appdata/artworks.json",
+    "appdata/places.json",
+    "appdata/heritages.json",
+    "appdata/badges.json",
+  ];
 
   // The point of the attribute below is to have a full, sorted list of all
   // discoveries no matter their type. It makes some things easier, for
@@ -46,6 +61,10 @@ export class UserData {
 
       if (typeof content.data === "string") {
         this.data = JSON.parse(content.data);
+        if (typeof this.data.schemaVersion !== "number") {
+          this.data.schemaVersion = 0;
+          this.updateFile();
+        }
       }
 
       console.log(this.type + " db: successfully populated database.");
@@ -114,8 +133,29 @@ export class UserData {
         heritages: [],
       },
       mapStyle: "osm", // Preferred map style (not in use @ the moment)
+      schemaVersion: this.DATA_SCHEMA_VERSION,
     };
 
+    this.updateFile();
+  }
+
+  public static async ensureDataSchemaUpToDate() {
+    await this.populate();
+    const storedVersion = this.data?.schemaVersion ?? 0;
+
+    if (storedVersion === this.DATA_SCHEMA_VERSION) return;
+
+    console.log(
+      `Data schema mismatch detected (current: ${storedVersion}, expected: ${this.DATA_SCHEMA_VERSION}). Refreshing local databases.`,
+    );
+
+    await this.deleteLocalDatabaseFiles();
+    await this.invalidateCacheFile();
+
+    this.sortedDiscoveries = [];
+    this.sortedDiscoveriesDistance = [];
+
+    this.data.schemaVersion = this.DATA_SCHEMA_VERSION;
     this.updateFile();
   }
   public static async getFromServer() {
@@ -150,13 +190,25 @@ export class UserData {
 
       if (typeof content.data === "string") {
         const parsed = JSON.parse(content.data);
-        this.sortedDiscoveries = parsed.map((discovery: any) => {
+        const cachePayload = this.parseCachePayload(parsed);
+
+        if (!cachePayload || cachePayload.version !== this.CACHE_SCHEMA_VERSION) {
+          console.log("Cache schema mismatch detected. Rebuilding cache.");
+          await this.invalidateCacheFile();
+          await this.buildCache();
+          this.sortByDistance();
+          return;
+        }
+
+        this.sortedDiscoveries = cachePayload.data.map((discovery: any) => {
           if (discovery.dType === "artwork")
             return ArtworkFactory.createArtwork(discovery);
           else if (discovery.dType === "place")
             return PlaceFactory.createPlace(discovery);
           else return new Heritage(discovery);
         });
+        this.sortByDistance();
+        return;
       }
     } catch (err) {
       console.log("Failed to load cache, building it.");
@@ -232,10 +284,58 @@ export class UserData {
 
     await Filesystem.writeFile({
       path: this.cachePath,
-      data: JSON.stringify(this.sortedDiscoveries),
+      data: JSON.stringify({
+        version: this.CACHE_SCHEMA_VERSION,
+        data: this.sortedDiscoveries,
+      }),
       directory: Directory.Cache,
       encoding: Encoding.UTF8,
     });
+  }
+
+  private static async deleteLocalDatabaseFiles() {
+    await Promise.all(
+      this.DATABASE_PATHS.map((path) =>
+        Filesystem.deleteFile({
+          path,
+          directory: Directory.Data,
+        }).catch(() => undefined),
+      ),
+    );
+  }
+
+  private static parseCachePayload(parsed: any): { version: number; data: any[] } | null {
+    if (!parsed) return null;
+
+    if (Array.isArray(parsed)) {
+      // Legacy cache file without schema info
+      return { version: 0, data: parsed };
+    }
+
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      Array.isArray(parsed.data)
+    ) {
+      return {
+        version:
+          typeof parsed.version === "number" ? parsed.version : Number(parsed.version) || 0,
+        data: parsed.data,
+      };
+    }
+
+    return null;
+  }
+
+  private static async invalidateCacheFile() {
+    try {
+      await Filesystem.deleteFile({
+        path: this.cachePath,
+        directory: Directory.Cache,
+      });
+    } catch (error) {
+      // File might already be missing; ignore
+    }
   }
 
   public static getSortedDiscoveriesAZ(sliceA?: number, sliceB?: number) {

--- a/src/internal/databases/UserData.ts
+++ b/src/internal/databases/UserData.ts
@@ -24,11 +24,11 @@ export class UserData {
   private static cachePath = "discoveries_sorted.json";
   private static type = "preferences";
   // Keep these version counters in sync with our storage formats.
-  // - Bump CACHE_SCHEMA_VERSION whenever the shape of discoveries_sorted.json (the
+  // - Increment CACHE_SCHEMA_VERSION whenever the shape of discoveries_sorted.json (the
   //   cached, sorted discovery list we store via Filesystem in Directory.Cache)
   //   changes
   //   (e.g., we add/remove fields, rename properties, or alter the wrapper structure).
-  // - Bump DATA_SCHEMA_VERSION whenever preferences.json or the downloaded DB JSON
+  // - Increment DATA_SCHEMA_VERSION whenever preferences.json or the downloaded DB JSON
   //   payloads (artworks/places/heritages/badges) change in a way that requires us to
   //   wipe and repopulate local files for older installs. This ensures users automatically
   //   refresh their local data after we ship schema-affecting releases.

--- a/src/internal/databases/UserData.ts
+++ b/src/internal/databases/UserData.ts
@@ -24,12 +24,15 @@ export class UserData {
   private static cachePath = "discoveries_sorted.json";
   private static type = "preferences";
   // Keep these version counters in sync with our storage formats.
-  // - Bump CACHE_SCHEMA_VERSION whenever the shape of discoveries_sorted.json changes
+  // - Bump CACHE_SCHEMA_VERSION whenever the shape of discoveries_sorted.json (the
+  //   cached, sorted discovery list we store via Filesystem in Directory.Cache)
+  //   changes
   //   (e.g., we add/remove fields, rename properties, or alter the wrapper structure).
   // - Bump DATA_SCHEMA_VERSION whenever preferences.json or the downloaded DB JSON
   //   payloads (artworks/places/heritages/badges) change in a way that requires us to
   //   wipe and repopulate local files for older installs. This ensures users automatically
   //   refresh their local data after we ship schema-affecting releases.
+  //   (e.g., new/removed/renamed field to the artworks API, etc.)
   private static readonly CACHE_SCHEMA_VERSION = 1;
   private static readonly DATA_SCHEMA_VERSION = 1;
   private static readonly DATABASE_PATHS = [

--- a/src/views/DataLoadingPage.vue
+++ b/src/views/DataLoadingPage.vue
@@ -37,44 +37,46 @@ export default {
     };
   },
 
-  mounted() {
-    /* Initializing all databases */
-    Promise.all([
-      ArtworkDatabase.populate(),
-      PlaceDatabase.populate(),
-      HeritageDatabase.populate(),
-      BadgeDatabase.populate(),
-    ])
-      .catch(() => {
-        this.showAlert("Impossible de se connecter à internet !");
-      })
-      .then(() => Promise.all([UserData.getFromServer(), UserData.loadCache()]))
-      .then(() => {
-        // Fetch collected badges
-        CollectedBadge.determineCollectedBadges();
-        // async functions, but DO NOT await (background tasks)
-        UserData.checkForDBUpdate();
-        UserData.tryUploadingPendingDiscoveries();
-      })
-      .then(() => {
+  async mounted() {
+    try {
+      await UserData.ensureDataSchemaUpToDate();
+      await Promise.all([
+        ArtworkDatabase.populate(),
+        PlaceDatabase.populate(),
+        HeritageDatabase.populate(),
+        BadgeDatabase.populate(),
+      ]);
+    } catch (error) {
+      console.error("Failed to populate local databases", error);
+      this.showAlert("Impossible de se connecter à internet !");
+      return;
+    }
 
-        // Set when account was created
-        // TODO check if this is the right way to do it
-        try {
-          if (UserData.getWhenAccountCreated() === "") {
-            UserData.setWhenAccountCreated();
-            console.log("'whenAccountCreated' value fetched and set in UserData.");
-          }
-        } catch (error) {
-          this.showAlert("Error: couldn't get when account was created by API.");
-        }
+    try {
+      await Promise.all([UserData.getFromServer(), UserData.loadCache()]);
+    } catch (err) {
+      throw new Error(`Could not retrieve user data (${err})`);
+    }
 
-        this.ionToastErrorMessageIsOpen = false;
-        this.$router.replace("/tabs/map");
-      })
-      .catch((err) => {
-        throw new Error(`Could not retrieve user data (${err})`);
-      });
+    // Fetch collected badges
+    CollectedBadge.determineCollectedBadges();
+    // async functions, but DO NOT await (background tasks)
+    UserData.checkForDBUpdate();
+    UserData.tryUploadingPendingDiscoveries();
+
+    // Set when account was created
+    // TODO check if this is the right way to do it
+    try {
+      if (UserData.getWhenAccountCreated() === "") {
+        UserData.setWhenAccountCreated();
+        console.log("'whenAccountCreated' value fetched and set in UserData.");
+      }
+    } catch (error) {
+      this.showAlert("Error: couldn't get when account was created by API.");
+    }
+
+    this.ionToastErrorMessageIsOpen = false;
+    this.$router.replace("/tabs/map");
   },
 
   methods: {


### PR DESCRIPTION
## Summary
- add `CACHE_SCHEMA_VERSION` and `DATA_SCHEMA_VERSION` so we can automatically wipe stale files after schema-affecting releases

- `CACHE_SCHEMA_VERSION` tracks the structure of our client-side cache. If we change how that cached list is serialized (new/removed fields, renamed props, different wrapper) we bump this so older cache files get discarded and rebuilt.

- `DATA_SCHEMA_VERSION` tracks the persisted data we store under `Directory.Data`: `preferences.json` and the downloaded DB dumps (`appdata/artworks.json`, etc.) that mirror the server’s payloads. If those files’ shape changes in a way older installs can’t safely read, we bump this so the app wipes and repopulates them from the backend.

- increment `CACHE_SCHEMA_VERSION` whenever the shape of `discoveries_sorted.json` (the cached, sorted discovery list we store via Filesystem in `Directory.Cache`) changes 
(e.g. new/removed fields client-side, renamed props, wrapper tweaks)

- increment `DATA_SCHEMA_VERSION` whenever preferences.json or the downloaded DB payloads (artworks/places/heritages/badges) change in a way that requires a full repopulation 
(e.g., new/removed/renamed field to the artworks, heritages, places, badges server database API, etc.)