### PR TITLE
Inverted "Découvertes à proximite" modal chevron

### DIFF
--- a/src/components/MapContainer.vue
+++ b/src/components/MapContainer.vue
@@ -51,12 +51,15 @@
       </ion-button>
     </div>
 
-    <ion-accordion value="ionaccordion">
+    <ion-accordion value="ionaccordion" toggle-icon-slot="none">
       <!-- TODO Move recenter button with accordion and update when position changed -->
       <!-- TODO Put between 5 and 12 discoveries depending on discoveries in viewport and add number of discoveries in header?? (to confirm with team to understand what to do) -->
       <!-- TODO Check if discoveries match with user location when it changes -->
       <ion-item slot="header">
         <ion-label>Découvertes à proximité: </ion-label>
+        <span class="custom-chevron" :class="{ open: ionAccordionOpen }">
+          <ion-icon :icon="chevronUpOutline"></ion-icon>
+        </span>
       </ion-item>
       <div slot="content" style="height: 20vh; width: 100vw">
         <ion-list :inset="false" lines="none">
@@ -163,7 +166,7 @@
 
 <script>
 import "ol/ol.css";
-import { arrowForward as arrowRightIcon } from "ionicons/icons";
+import { arrowForward as arrowRightIcon, chevronUpOutline } from "ionicons/icons";
 import {
   IonButton,
   IonContent,
@@ -387,6 +390,7 @@ export default {
       // if location is not available, use the default zoom level = 4.5
       TILE_LAYER: layer,
       arrowRightIcon,
+      chevronUpOutline,
       customLocationIconBlack,
       customLocationIconPurple,
       isAlertOpen: false,

--- a/src/theme/Map.css
+++ b/src/theme/Map.css
@@ -36,6 +36,19 @@ ion-accordion-group.closestDiscoveriesAccordion ion-accordion ion-item[slot="hea
     padding: 0.8vh 0;
 }
 
+/* Custom chevron for accordion - points up when closed, down when open */
+.custom-chevron {
+    display: flex;
+    align-items: center;
+    margin-right: 1vw;
+    font-size: 20px;
+    transition: transform 0.3s ease;
+}
+
+.custom-chevron.open {
+    transform: rotate(180deg);
+}
+
 ion-accordion-group.closestDiscoveriesAccordion ion-accordion div[slot="content"] ion-list {
     display: flex;
     overflow-x: scroll;


### PR DESCRIPTION
Added a custom chevron that now points down when the modal is expanded and down when it is closed.

<img width="267" height="319" alt="image" src="https://github.com/user-attachments/assets/4eab2171-6fd2-4263-9845-aaa60d016ac5" />
<img width="265" height="183" alt="image" src="https://github.com/user-attachments/assets/ae3996b6-bc88-43fd-a910-2b57083070c0" />